### PR TITLE
Add audience reactions: floating emoji reactions from phones to TV

### DIFF
--- a/__tests__/app/tv/page.test.tsx
+++ b/__tests__/app/tv/page.test.tsx
@@ -103,6 +103,16 @@ vi.mock("@/components/tv/ApplausePlayer", () => ({
   ApplausePlayer: () => <div data-testid="applause-player">ApplausePlayer</div>,
 }));
 
+vi.mock("@/components/tv/FloatingReactions", () => ({
+  FloatingReactions: () => (
+    <div data-testid="floating-reactions">FloatingReactions</div>
+  ),
+}));
+
+vi.mock("@/hooks/useReactions", () => ({
+  useReactions: () => ({ reactions: [] }),
+}));
+
 describe("TV Display Page", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/__tests__/components/mobile/ReactionsPanel.test.tsx
+++ b/__tests__/components/mobile/ReactionsPanel.test.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ReactionsPanel } from "@/components/mobile/ReactionsPanel";
+
+describe("ReactionsPanel", () => {
+  const mockOnReaction = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the FAB button in closed state", () => {
+    render(<ReactionsPanel onReaction={mockOnReaction} />);
+
+    const fab = screen.getByLabelText("Open reactions");
+    expect(fab).toBeInTheDocument();
+  });
+
+  it("does not show emoji buttons when closed", () => {
+    render(<ReactionsPanel onReaction={mockOnReaction} />);
+
+    expect(screen.queryByTestId("reaction-🔥")).not.toBeInTheDocument();
+  });
+
+  it("shows emoji buttons when FAB is clicked", () => {
+    render(<ReactionsPanel onReaction={mockOnReaction} />);
+
+    fireEvent.click(screen.getByLabelText("Open reactions"));
+
+    expect(screen.getByTestId("reaction-🔥")).toBeInTheDocument();
+    expect(screen.getByTestId("reaction-❤️")).toBeInTheDocument();
+    expect(screen.getByTestId("reaction-🎤")).toBeInTheDocument();
+    expect(screen.getByTestId("reaction-👏")).toBeInTheDocument();
+    expect(screen.getByTestId("reaction-😂")).toBeInTheDocument();
+    expect(screen.getByTestId("reaction-🙌")).toBeInTheDocument();
+  });
+
+  it("calls onReaction with the emoji when an emoji button is tapped", () => {
+    render(<ReactionsPanel onReaction={mockOnReaction} />);
+
+    fireEvent.click(screen.getByLabelText("Open reactions"));
+    fireEvent.click(screen.getByTestId("reaction-🔥"));
+
+    expect(mockOnReaction).toHaveBeenCalledWith("🔥");
+  });
+
+  it("shows close button when open", () => {
+    render(<ReactionsPanel onReaction={mockOnReaction} />);
+
+    fireEvent.click(screen.getByLabelText("Open reactions"));
+
+    expect(screen.getByLabelText("Close reactions")).toBeInTheDocument();
+  });
+
+  it("hides emoji buttons when close is clicked", () => {
+    render(<ReactionsPanel onReaction={mockOnReaction} />);
+
+    fireEvent.click(screen.getByLabelText("Open reactions"));
+    expect(screen.getByTestId("reaction-🔥")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Close reactions"));
+    expect(screen.queryByTestId("reaction-🔥")).not.toBeInTheDocument();
+  });
+
+  it("applies scale animation on tap then resets", () => {
+    render(<ReactionsPanel onReaction={mockOnReaction} />);
+
+    fireEvent.click(screen.getByLabelText("Open reactions"));
+    const btn = screen.getByTestId("reaction-❤️");
+
+    fireEvent.click(btn);
+    expect(btn.className).toContain("scale-125");
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(btn.className).toContain("scale-100");
+  });
+});

--- a/__tests__/components/tv/FloatingReactions.test.tsx
+++ b/__tests__/components/tv/FloatingReactions.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { FloatingReactions } from "@/components/tv/FloatingReactions";
+import { Reaction } from "@/hooks/useReactions";
+
+const makeReaction = (
+  id: string,
+  emoji: string,
+  userName: string
+): Reaction => ({
+  id,
+  emoji,
+  userName,
+  timestamp: Date.now(),
+});
+
+describe("FloatingReactions", () => {
+  it("renders nothing when reactions array is empty", () => {
+    const { container } = render(<FloatingReactions reactions={[]} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders floating reactions with emojis and usernames", () => {
+    const reactions = [
+      makeReaction("r1", "🔥", "Alice"),
+      makeReaction("r2", "❤️", "Bob"),
+    ];
+
+    render(<FloatingReactions reactions={reactions} />);
+
+    const elements = screen.getAllByTestId("floating-reaction");
+    expect(elements).toHaveLength(2);
+    expect(elements[0]).toHaveTextContent("🔥");
+    expect(elements[0]).toHaveTextContent("Alice");
+    expect(elements[1]).toHaveTextContent("❤️");
+    expect(elements[1]).toHaveTextContent("Bob");
+  });
+
+  it("positions reactions based on their ID hash", () => {
+    const reactions = [makeReaction("abc", "🎤", "Charlie")];
+
+    render(<FloatingReactions reactions={reactions} />);
+
+    const el = screen.getByTestId("floating-reaction");
+    const style = el.getAttribute("style");
+    expect(style).toContain("left:");
+    expect(style).toMatch(/left: \d+%/);
+  });
+
+  it("renders the container with pointer-events-none", () => {
+    const reactions = [makeReaction("r1", "👏", "Dave")];
+
+    render(<FloatingReactions reactions={reactions} />);
+
+    const container = screen.getByTestId("floating-reactions-container");
+    expect(container.className).toContain("pointer-events-none");
+  });
+});

--- a/e2e/features/audience-reactions.feature
+++ b/e2e/features/audience-reactions.feature
@@ -1,0 +1,32 @@
+@multi-user
+Feature: Audience Reactions
+  As audience members watching a karaoke performance
+  We want to send emoji reactions from our phones
+  So that the TV display shows real-time encouragement
+
+  Scenario: Audience member sends a reaction that appears on the TV
+    Given "Alice" has joined the session on device 1
+    And the TV display is open
+    And a song is currently playing
+    When Alice sends a "🔥" reaction
+    Then the TV display shows the "🔥" reaction floating across the screen
+
+  Scenario: Multiple users send reactions simultaneously
+    Given "Alice" has joined the session on device 1
+    And "Bob" has joined the session on device 2
+    And the TV display is open
+    And a song is currently playing
+    When Alice sends a "🎤" reaction
+    And Bob sends a "❤️" reaction
+    Then the TV display shows both reactions
+
+  Scenario: Reactions are only available during playback
+    Given "Alice" has joined the session on device 1
+    And no songs are in the queue
+    Then Alice does not see the reactions panel
+
+  Scenario: Reaction panel shows available emoji options
+    Given "Alice" has joined the session on device 1
+    And a song is currently playing
+    Then Alice sees the reactions panel with emoji options
+    And the available reactions include "🔥", "❤️", "🎤", "👏", "😂", "🙌"

--- a/e2e/steps/audience-reactions.steps.ts
+++ b/e2e/steps/audience-reactions.steps.ts
@@ -62,7 +62,7 @@ async function joinSession(page: Page, userName: string): Promise<void> {
   await page.goto(BASE_URL);
   const nameInput = page.getByTestId("username-input");
   await nameInput.fill(userName);
-  const joinButton = page.getByTestId("join-button");
+  const joinButton = page.getByTestId("join-session-button");
   await joinButton.click();
   await page.waitForSelector('[data-testid="search-input"]', {
     timeout: 15000,
@@ -73,11 +73,12 @@ async function addSongToQueue(page: Page): Promise<void> {
   const artistItem = page.getByTestId("artist-item").first();
   await artistItem.click();
   const addButton = page.getByTestId("add-song-button").first();
-  await addButton.waitFor({ state: "visible", timeout: 15000 });
+  await addButton.waitFor({ state: "visible", timeout: 30000 });
   await addButton.click();
-  const closeButton = page.getByTestId("confirmation-close");
-  await closeButton.waitFor({ state: "visible", timeout: 5000 });
-  await closeButton.click();
+  const dialog = page.locator("[data-testid='confirmation-dialog']");
+  await dialog.waitFor({ timeout: 10000 });
+  await dialog.locator("button[aria-label='Close']").click();
+  await dialog.waitFor({ state: "hidden", timeout: 5000 });
 }
 
 Given(
@@ -91,14 +92,14 @@ Given(
 
 Given("the TV display is open", async ({ tvPage }) => {
   await tvPage.goto(`${BASE_URL}/tv`);
-  await tvPage.waitForSelector('[data-testid="tv-display"]', {
+  await tvPage.waitForSelector('[data-testid="tv-interface"]', {
     timeout: 15000,
   });
 });
 
-Given("a song is currently playing", async ({ alicePage, tvPage }) => {
+Given("a song is currently playing", async ({ alicePage }) => {
   await addSongToQueue(alicePage);
-  await tvPage.waitForSelector('[data-testid="now-playing"]', {
+  await alicePage.waitForSelector('[data-testid="reactions-panel"]', {
     timeout: 30000,
   });
 });

--- a/e2e/steps/audience-reactions.steps.ts
+++ b/e2e/steps/audience-reactions.steps.ts
@@ -1,0 +1,169 @@
+import { expect, Page, BrowserContext } from "@playwright/test";
+import { test as base, createBdd } from "playwright-bdd";
+
+const test = base.extend<{
+  alicePage: Page;
+  aliceContext: BrowserContext;
+  bobPage: Page;
+  bobContext: BrowserContext;
+  tvPage: Page;
+  tvContext: BrowserContext;
+}>({
+  aliceContext: async ({ browser }, use) => {
+    const context = await browser.newContext();
+    await use(context);
+    await context.close();
+  },
+  alicePage: async ({ aliceContext }, use) => {
+    const page = await aliceContext.newPage();
+    await use(page);
+  },
+  bobContext: async ({ browser }, use) => {
+    const context = await browser.newContext();
+    await use(context);
+    await context.close();
+  },
+  bobPage: async ({ bobContext }, use) => {
+    const page = await bobContext.newPage();
+    await use(page);
+  },
+  tvContext: async ({ browser }, use) => {
+    const context = await browser.newContext();
+    await use(context);
+    await context.close();
+  },
+  tvPage: async ({ tvContext }, use) => {
+    const page = await tvContext.newPage();
+    await use(page);
+  },
+});
+
+export { test };
+const { Given, When, Then } = createBdd(test);
+
+const BASE_URL = "http://localhost:3000";
+
+async function clearQueue(page: Page): Promise<void> {
+  const response = await page.request.get(`${BASE_URL}/api/queue`);
+  const data = await response.json();
+  if (data.queue) {
+    for (const item of data.queue) {
+      await page.request.delete(
+        `${BASE_URL}/api/queue?queueItemId=${item.id}&userId=test`
+      );
+    }
+  }
+  await page.request.put(`${BASE_URL}/api/queue`, {
+    data: { action: "skip", userId: "test" },
+  });
+}
+
+async function joinSession(page: Page, userName: string): Promise<void> {
+  await page.goto(BASE_URL);
+  const nameInput = page.getByTestId("username-input");
+  await nameInput.fill(userName);
+  const joinButton = page.getByTestId("join-button");
+  await joinButton.click();
+  await page.waitForSelector('[data-testid="search-input"]', {
+    timeout: 15000,
+  });
+}
+
+async function addSongToQueue(page: Page): Promise<void> {
+  const artistItem = page.getByTestId("artist-item").first();
+  await artistItem.click();
+  const addButton = page.getByTestId("add-song-button").first();
+  await addButton.waitFor({ state: "visible", timeout: 15000 });
+  await addButton.click();
+  const closeButton = page.getByTestId("confirmation-close");
+  await closeButton.waitFor({ state: "visible", timeout: 5000 });
+  await closeButton.click();
+}
+
+Given(
+  "{string} has joined the session on device {int}",
+  async ({ alicePage, bobPage }, name: string, device: number) => {
+    const page = device === 1 ? alicePage : bobPage;
+    if (device === 1) await clearQueue(page);
+    await joinSession(page, name);
+  }
+);
+
+Given("the TV display is open", async ({ tvPage }) => {
+  await tvPage.goto(`${BASE_URL}/tv`);
+  await tvPage.waitForSelector('[data-testid="tv-display"]', {
+    timeout: 15000,
+  });
+});
+
+Given("a song is currently playing", async ({ alicePage, tvPage }) => {
+  await addSongToQueue(alicePage);
+  await tvPage.waitForSelector('[data-testid="now-playing"]', {
+    timeout: 30000,
+  });
+});
+
+Given("no songs are in the queue", async ({ alicePage }) => {
+  await clearQueue(alicePage);
+});
+
+When(
+  "Alice sends a {string} reaction",
+  async ({ alicePage }, emoji: string) => {
+    const reactionButton = alicePage.getByTestId(`reaction-${emoji}`);
+    await reactionButton.waitFor({ state: "visible", timeout: 10000 });
+    await reactionButton.click();
+  }
+);
+
+When("Bob sends a {string} reaction", async ({ bobPage }, emoji: string) => {
+  const reactionButton = bobPage.getByTestId(`reaction-${emoji}`);
+  await reactionButton.waitFor({ state: "visible", timeout: 10000 });
+  await reactionButton.click();
+});
+
+Then(
+  "the TV display shows the {string} reaction floating across the screen",
+  async ({ tvPage }, emoji: string) => {
+    const reaction = tvPage.getByTestId("floating-reaction").filter({
+      hasText: emoji,
+    });
+    await reaction.waitFor({ state: "visible", timeout: 10000 });
+  }
+);
+
+Then("the TV display shows both reactions", async ({ tvPage }) => {
+  const reactions = tvPage.getByTestId("floating-reaction");
+  await expect(reactions).toHaveCount(2, { timeout: 10000 });
+});
+
+Then("Alice does not see the reactions panel", async ({ alicePage }) => {
+  const panel = alicePage.getByTestId("reactions-panel");
+  await expect(panel).toHaveCount(0);
+});
+
+Then(
+  "Alice sees the reactions panel with emoji options",
+  async ({ alicePage }) => {
+    const panel = alicePage.getByTestId("reactions-panel");
+    await panel.waitFor({ state: "visible", timeout: 10000 });
+  }
+);
+
+Then(
+  "the available reactions include {string}, {string}, {string}, {string}, {string}, {string}",
+  async (
+    { alicePage },
+    e1: string,
+    e2: string,
+    e3: string,
+    e4: string,
+    e5: string,
+    e6: string
+  ) => {
+    for (const emoji of [e1, e2, e3, e4, e5, e6]) {
+      const button = alicePage.getByTestId(`reaction-${emoji}`);
+      await expect(button).toBeVisible();
+    }
+  }
+);

--- a/e2e/steps/audience-reactions.steps.ts
+++ b/e2e/steps/audience-reactions.steps.ts
@@ -108,9 +108,17 @@ Given("no songs are in the queue", async ({ alicePage }) => {
   await clearQueue(alicePage);
 });
 
+async function openReactionsFab(page: Page): Promise<void> {
+  const fab = page
+    .getByTestId("reactions-panel")
+    .locator("button[aria-label='Open reactions']");
+  await fab.click();
+}
+
 When(
   "Alice sends a {string} reaction",
   async ({ alicePage }, emoji: string) => {
+    await openReactionsFab(alicePage);
     const reactionButton = alicePage.getByTestId(`reaction-${emoji}`);
     await reactionButton.waitFor({ state: "visible", timeout: 10000 });
     await reactionButton.click();
@@ -118,6 +126,7 @@ When(
 );
 
 When("Bob sends a {string} reaction", async ({ bobPage }, emoji: string) => {
+  await openReactionsFab(bobPage);
   const reactionButton = bobPage.getByTestId(`reaction-${emoji}`);
   await reactionButton.waitFor({ state: "visible", timeout: 10000 });
   await reactionButton.click();
@@ -162,6 +171,7 @@ Then(
     e5: string,
     e6: string
   ) => {
+    await openReactionsFab(alicePage);
     for (const emoji of [e1, e2, e3, e4, e5, e6]) {
       const button = alicePage.getByTestId(`reaction-${emoji}`);
       await expect(button).toBeVisible();

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,6 +35,12 @@ const adminSyncTestDir = defineBddConfig({
   steps: "e2e/steps/admin-playback-sync.steps.ts",
 });
 
+const audienceReactionsTestDir = defineBddConfig({
+  outputDir: ".features-gen/audience-reactions",
+  features: "e2e/features/audience-reactions.feature",
+  steps: "e2e/steps/audience-reactions.steps.ts",
+});
+
 const fullPlaybackTestDir = defineBddConfig({
   outputDir: ".features-gen/full-playback",
   features: "e2e/features/full-playback.feature",
@@ -61,6 +67,12 @@ export default defineConfig({
     {
       name: "multi-user",
       testDir: multiUserTestDir,
+      use: { ...devices["Desktop Chrome"] },
+      timeout: 90000,
+    },
+    {
+      name: "audience-reactions",
+      testDir: audienceReactionsTestDir,
       use: { ...devices["Desktop Chrome"] },
       timeout: 90000,
     },

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const { parse } = require("url");
 const next = require("next");
 const { Server } = require("socket.io");
 const fetch = require("node-fetch");
+const { handleSendReaction } = require("./server/reactions");
 
 // Simple rating generator for server-side use
 function generateRandomRating() {
@@ -1070,6 +1071,10 @@ app.prepare().then(() => {
       if (user) {
         user.lastSeen = new Date();
       }
+    });
+
+    socket.on("send-reaction", data => {
+      handleSendReaction(io, socket, data, connectedUsers, currentSession);
     });
 
     socket.on("disconnect", () => {

--- a/server/reactions.js
+++ b/server/reactions.js
@@ -1,0 +1,39 @@
+function handleSendReaction(io, socket, data, connectedUsers, currentSession) {
+  const user = connectedUsers.get(socket.id);
+  if (!user) {
+    socket.emit("error", {
+      code: "NOT_IN_SESSION",
+      message: "You must join a session first",
+    });
+    return;
+  }
+
+  if (!currentSession) {
+    socket.emit("error", {
+      code: "NOT_IN_SESSION",
+      message: "No active session",
+    });
+    return;
+  }
+
+  const { emoji } = data;
+  if (!emoji) {
+    socket.emit("error", {
+      code: "INVALID_REACTION",
+      message: "Emoji is required",
+    });
+    return;
+  }
+
+  const reaction = {
+    id: `reaction_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+    emoji,
+    userId: user.id,
+    timestamp: Date.now(),
+  };
+
+  const sessionId = currentSession.id || "main-session";
+  io.to(sessionId).emit("reaction-received", reaction);
+}
+
+module.exports = { handleSendReaction };

--- a/server/reactions.js
+++ b/server/reactions.js
@@ -29,6 +29,7 @@ function handleSendReaction(io, socket, data, connectedUsers, currentSession) {
     id: `reaction_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
     emoji,
     userId: user.id,
+    userName: user.name,
     timestamp: Date.now(),
   };
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,3 +48,22 @@ input[type="email"]:focus,
 input[type="password"]:focus {
   color: #111827 !important;
 }
+
+/* Floating reaction animation for TV display */
+@keyframes float-up {
+  0% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+  70% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(-100vh) scale(1.2);
+    opacity: 0;
+  }
+}
+
+.animate-float-up {
+  animation: float-up 3s ease-out forwards;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -114,12 +114,8 @@ export default function Home() {
         queueCount={queue.filter(item => item.status === "pending").length}
       />
 
-      {/* Reactions Panel - visible during playback */}
-      {currentSong && (
-        <div className="px-4 pt-2">
-          <ReactionsPanel onReaction={sendReaction} />
-        </div>
-      )}
+      {/* Reactions FAB - visible during playback */}
+      {currentSong && <ReactionsPanel onReaction={sendReaction} />}
 
       {/* Main Content */}
       <div className="flex-1 overflow-hidden">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { SearchInterface } from "@/components/mobile/SearchInterface";
 import { QueueView } from "@/components/mobile/QueueView";
 import { UserSetup } from "@/components/mobile/UserSetup";
 import { NavigationTabs } from "@/components/mobile/NavigationTabs";
+import { ReactionsPanel } from "@/components/mobile/ReactionsPanel";
 import { PWAInstaller } from "@/components/PWAInstaller";
 import {
   getConnectionStatusColor,
@@ -23,6 +24,7 @@ export default function Home() {
     joinSession,
     addSong,
     removeSong,
+    sendReaction,
     session,
     queue,
     currentSong,
@@ -111,6 +113,13 @@ export default function Home() {
         onTabChange={setActiveTab}
         queueCount={queue.filter(item => item.status === "pending").length}
       />
+
+      {/* Reactions Panel - visible during playback */}
+      {currentSong && (
+        <div className="px-4 pt-2">
+          <ReactionsPanel onReaction={sendReaction} />
+        </div>
+      )}
 
       {/* Main Content */}
       <div className="flex-1 overflow-hidden">

--- a/src/app/tv/page.tsx
+++ b/src/app/tv/page.tsx
@@ -7,6 +7,7 @@ import { AudioPlayer } from "@/components/tv/AudioPlayer";
 import { NextUpSidebar } from "@/components/tv/NextUpSidebar";
 import { QRCode } from "@/components/tv/QRCode";
 import { ApplausePlayer } from "@/components/tv/ApplausePlayer";
+import { FloatingReactions } from "@/components/tv/FloatingReactions";
 import {
   ConnectionStatus,
   AutoplayCountdownOverlay,
@@ -28,6 +29,7 @@ export default function TVDisplay() {
     showQueuePreview,
     autoplayCountdown,
     transitionState,
+    reactions,
     setShowHostControls,
     setShowQueuePreview,
     handleRatingComplete,
@@ -133,6 +135,8 @@ export default function TVDisplay() {
       />
 
       <NextUpSidebar queue={queue} currentSong={currentSong} />
+
+      <FloatingReactions reactions={reactions} />
 
       <div className="absolute bottom-4 left-4 text-gray-500 text-sm">
         <div className="bg-black bg-opacity-50 rounded px-3 py-2">

--- a/src/components/mobile/ReactionsPanel.tsx
+++ b/src/components/mobile/ReactionsPanel.tsx
@@ -16,6 +16,7 @@ const REACTION_EMOJIS = [
 ] as const;
 
 export function ReactionsPanel({ onReaction }: ReactionsPanelProps) {
+  const [isOpen, setIsOpen] = useState(false);
   const [animatingEmoji, setAnimatingEmoji] = useState<string | null>(null);
 
   const handleTap = (emoji: string) => {
@@ -25,26 +26,37 @@ export function ReactionsPanel({ onReaction }: ReactionsPanelProps) {
   };
 
   return (
-    <div
-      data-testid="reactions-panel"
-      className="bg-white rounded-lg p-3 shadow-sm border"
-    >
-      <div className="flex items-center justify-around">
-        {REACTION_EMOJIS.map(emoji => (
-          <button
-            key={emoji}
-            data-testid={`reaction-${emoji}`}
-            onClick={() => handleTap(emoji)}
-            className={`text-2xl p-2 rounded-full active:bg-gray-100 transition-transform duration-200 ${
-              animatingEmoji === emoji ? "scale-125" : "scale-100"
-            }`}
-            type="button"
-            aria-label={`React with ${emoji}`}
-          >
-            {emoji}
-          </button>
-        ))}
-      </div>
+    <div data-testid="reactions-panel" className="fixed bottom-6 right-4 z-40">
+      {isOpen && (
+        <div className="absolute bottom-16 right-0 flex flex-col gap-2 items-center mb-2">
+          {REACTION_EMOJIS.map(emoji => (
+            <button
+              key={emoji}
+              data-testid={`reaction-${emoji}`}
+              onClick={() => handleTap(emoji)}
+              className={`w-12 h-12 rounded-full bg-white shadow-lg flex items-center justify-center text-2xl transition-transform duration-200 active:bg-gray-100 ${
+                animatingEmoji === emoji ? "scale-125" : "scale-100"
+              }`}
+              type="button"
+              aria-label={`React with ${emoji}`}
+            >
+              {emoji}
+            </button>
+          ))}
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className={`w-14 h-14 rounded-full shadow-lg flex items-center justify-center text-2xl transition-all duration-200 ${
+          isOpen
+            ? "bg-gray-700 text-white rotate-45"
+            : "bg-purple-600 text-white"
+        }`}
+        aria-label={isOpen ? "Close reactions" : "Open reactions"}
+      >
+        {isOpen ? "+" : "🎉"}
+      </button>
     </div>
   );
 }

--- a/src/components/mobile/ReactionsPanel.tsx
+++ b/src/components/mobile/ReactionsPanel.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+
+interface ReactionsPanelProps {
+  onReaction: (emoji: string) => void;
+}
+
+const REACTION_EMOJIS = [
+  "\u{1F525}",
+  "❤️",
+  "\u{1F3A4}",
+  "\u{1F44F}",
+  "\u{1F602}",
+  "\u{1F64C}",
+] as const;
+
+export function ReactionsPanel({ onReaction }: ReactionsPanelProps) {
+  const [animatingEmoji, setAnimatingEmoji] = useState<string | null>(null);
+
+  const handleTap = (emoji: string) => {
+    onReaction(emoji);
+    setAnimatingEmoji(emoji);
+    setTimeout(() => setAnimatingEmoji(null), 200);
+  };
+
+  return (
+    <div
+      data-testid="reactions-panel"
+      className="bg-white rounded-lg p-3 shadow-sm border"
+    >
+      <div className="flex items-center justify-around">
+        {REACTION_EMOJIS.map(emoji => (
+          <button
+            key={emoji}
+            data-testid={`reaction-${emoji}`}
+            onClick={() => handleTap(emoji)}
+            className={`text-2xl p-2 rounded-full active:bg-gray-100 transition-transform duration-200 ${
+              animatingEmoji === emoji ? "scale-125" : "scale-100"
+            }`}
+            type="button"
+            aria-label={`React with ${emoji}`}
+          >
+            {emoji}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/tv/FloatingReactions.tsx
+++ b/src/components/tv/FloatingReactions.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useMemo } from "react";
+import { Reaction } from "@/hooks/useReactions";
+
+interface FloatingReactionsProps {
+  reactions: Reaction[];
+}
+
+export function FloatingReactions({ reactions }: FloatingReactionsProps) {
+  // Generate stable random horizontal positions per reaction ID
+  const positions = useMemo(() => {
+    const map = new Map<string, number>();
+    reactions.forEach(r => {
+      if (!map.has(r.id)) {
+        // Simple hash from ID to get a pseudo-random position 5-95%
+        const hash = r.id
+          .split("")
+          .reduce((acc, char) => acc + char.charCodeAt(0), 0);
+        map.set(r.id, 5 + (hash % 90));
+      }
+    });
+    return map;
+  }, [reactions]);
+
+  if (reactions.length === 0) return null;
+
+  return (
+    <div
+      data-testid="floating-reactions-container"
+      className="fixed inset-0 z-50 pointer-events-none overflow-hidden"
+    >
+      {reactions.map(reaction => (
+        <span
+          key={reaction.id}
+          data-testid="floating-reaction"
+          className="absolute bottom-0 text-5xl animate-float-up"
+          style={{ left: `${positions.get(reaction.id) ?? 50}%` }}
+        >
+          {reaction.emoji}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/components/tv/FloatingReactions.tsx
+++ b/src/components/tv/FloatingReactions.tsx
@@ -37,8 +37,14 @@ export function FloatingReactions({ reactions }: FloatingReactionsProps) {
           className="absolute bottom-20 flex flex-col items-center animate-float-up"
           style={{ left: `${positions.get(reaction.id) ?? 50}%` }}
         >
-          <span className="text-7xl drop-shadow-lg">{reaction.emoji}</span>
-          <span className="mt-2 px-6 py-2 rounded-full bg-gray-900/90 text-2xl font-bold text-white whitespace-nowrap drop-shadow-lg">
+          <span className="text-6xl drop-shadow-lg">{reaction.emoji}</span>
+          <span
+            className="mt-2 px-4 py-1 rounded-full text-lg font-bold whitespace-nowrap"
+            style={{
+              backgroundColor: "rgba(255, 255, 255, 0.85)",
+              color: "#1a1a2e",
+            }}
+          >
             {reaction.userName}
           </span>
         </div>

--- a/src/components/tv/FloatingReactions.tsx
+++ b/src/components/tv/FloatingReactions.tsx
@@ -31,14 +31,17 @@ export function FloatingReactions({ reactions }: FloatingReactionsProps) {
       className="fixed inset-0 z-50 pointer-events-none overflow-hidden"
     >
       {reactions.map(reaction => (
-        <span
+        <div
           key={reaction.id}
           data-testid="floating-reaction"
-          className="absolute bottom-0 text-5xl animate-float-up"
+          className="absolute bottom-20 flex flex-col items-center animate-float-up"
           style={{ left: `${positions.get(reaction.id) ?? 50}%` }}
         >
-          {reaction.emoji}
-        </span>
+          <span className="text-7xl drop-shadow-lg">{reaction.emoji}</span>
+          <span className="mt-2 px-6 py-2 rounded-full bg-gray-900/90 text-2xl font-bold text-white whitespace-nowrap drop-shadow-lg">
+            {reaction.userName}
+          </span>
+        </div>
       ))}
     </div>
   );

--- a/src/hooks/tv-display/types.ts
+++ b/src/hooks/tv-display/types.ts
@@ -5,6 +5,7 @@ import {
   PlaybackCommand,
   KaraokeSession,
 } from "@/types";
+import { Reaction } from "@/hooks/useReactions";
 
 export interface UseTVDisplayReturn {
   // State
@@ -19,6 +20,7 @@ export interface UseTVDisplayReturn {
   showQueuePreview: boolean;
   autoplayCountdown: number | null;
   transitionState: TransitionState;
+  reactions: Reaction[];
 
   // State setters
   setShowHostControls: (value: boolean) => void;

--- a/src/hooks/tv-display/useTVDisplay.ts
+++ b/src/hooks/tv-display/useTVDisplay.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useWebSocket } from "@/hooks/useWebSocket";
 import { useConfig } from "@/contexts/ConfigContext";
+import { useReactions } from "@/hooks/useReactions";
 import { UseTVDisplayReturn } from "./types";
 import { useTransitionState } from "./useTransitionState";
 import { useAutoplay } from "./useAutoplay";
@@ -17,6 +18,7 @@ export function useTVDisplay(): UseTVDisplayReturn {
   const [isClient, setIsClient] = useState(false);
 
   const {
+    socket,
     isConnected,
     joinSession,
     session,
@@ -101,6 +103,9 @@ export function useTVDisplay(): UseTVDisplayReturn {
       timeUpdateInterval: config.timeUpdateInterval,
     });
 
+  // Floating reactions
+  const { reactions } = useReactions(socket);
+
   return {
     isClient,
     isConnected,
@@ -113,6 +118,7 @@ export function useTVDisplay(): UseTVDisplayReturn {
     showQueuePreview,
     autoplayCountdown,
     transitionState,
+    reactions,
     setShowHostControls,
     setShowQueuePreview,
     handleRatingComplete,

--- a/src/hooks/useReactions.ts
+++ b/src/hooks/useReactions.ts
@@ -6,6 +6,7 @@ import { Socket } from "socket.io-client";
 export interface Reaction {
   id: string;
   emoji: string;
+  userName: string;
   timestamp: number;
 }
 
@@ -29,10 +30,15 @@ export function useReactions(socket: Socket | null): UseReactionsReturn {
   useEffect(() => {
     if (!socket) return;
 
-    const handleReaction = (data: { id: string; emoji: string }) => {
+    const handleReaction = (data: {
+      id: string;
+      emoji: string;
+      userName: string;
+    }) => {
       const reaction: Reaction = {
         id: data.id,
         emoji: data.emoji,
+        userName: data.userName,
         timestamp: Date.now(),
       };
 

--- a/src/hooks/useReactions.ts
+++ b/src/hooks/useReactions.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Socket } from "socket.io-client";
+
+export interface Reaction {
+  id: string;
+  emoji: string;
+  timestamp: number;
+}
+
+interface UseReactionsReturn {
+  reactions: Reaction[];
+}
+
+const REACTION_LIFETIME_MS = 3500;
+
+export function useReactions(socket: Socket | null): UseReactionsReturn {
+  const [reactions, setReactions] = useState<Reaction[]>([]);
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map()
+  );
+
+  const removeReaction = useCallback((id: string) => {
+    setReactions(prev => prev.filter(r => r.id !== id));
+    timersRef.current.delete(id);
+  }, []);
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleReaction = (data: { id: string; emoji: string }) => {
+      const reaction: Reaction = {
+        id: data.id,
+        emoji: data.emoji,
+        timestamp: Date.now(),
+      };
+
+      setReactions(prev => [...prev, reaction]);
+
+      const timer = setTimeout(() => {
+        removeReaction(reaction.id);
+      }, REACTION_LIFETIME_MS);
+
+      timersRef.current.set(reaction.id, timer);
+    };
+
+    socket.on("reaction-received", handleReaction);
+
+    return () => {
+      socket.off("reaction-received", handleReaction);
+    };
+  }, [socket, removeReaction]);
+
+  // Clean up all timers on unmount
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      timers.forEach(timer => clearTimeout(timer));
+      timers.clear();
+    };
+  }, []);
+
+  return { reactions };
+}

--- a/src/hooks/useWebSocket/handlerTypes.ts
+++ b/src/hooks/useWebSocket/handlerTypes.ts
@@ -56,6 +56,7 @@ export interface SocketActions {
   skipSong: () => void;
   songEnded: () => void;
   startNextSong: () => void;
+  sendReaction: (emoji: string) => void;
   updateLocalPlaybackState: (updates: Partial<PlaybackState>) => void;
   setSongCompletedHandler: (
     handler: (data: { song: QueueItem; rating: unknown }) => void

--- a/src/hooks/useWebSocket/useSocketActions.ts
+++ b/src/hooks/useWebSocket/useSocketActions.ts
@@ -94,6 +94,15 @@ export function useSocketActions(deps: ActionDeps): SocketActions {
     [emitIfConnected]
   );
 
+  const sendReaction = useCallback(
+    (emoji: string) => {
+      if (socketRef.current) {
+        socketRef.current.emit("send-reaction", { emoji });
+      }
+    },
+    [socketRef]
+  );
+
   const updateLocalPlaybackState = useCallback(
     (updates: Partial<PlaybackState>) => {
       setPlaybackState(prevState => {
@@ -130,6 +139,7 @@ export function useSocketActions(deps: ActionDeps): SocketActions {
     skipSong,
     songEnded,
     startNextSong,
+    sendReaction,
     updateLocalPlaybackState,
     setSongCompletedHandler,
   };

--- a/src/hooks/useWebSocket/useWebSocket.ts
+++ b/src/hooks/useWebSocket/useWebSocket.ts
@@ -23,6 +23,7 @@ interface WebSocketHookReturn {
   skipSong: () => void;
   songEnded: () => void;
   startNextSong: () => void;
+  sendReaction: (emoji: string) => void;
   updateLocalPlaybackState: (updates: Partial<PlaybackState>) => void;
   setSongCompletedHandler: (
     handler: (data: { song: QueueItem; rating: unknown }) => void


### PR DESCRIPTION
## Summary
- Mobile users can send emoji reactions (🔥❤️🎤👏😂🙌) during song playback
- Reactions broadcast via WebSocket and animate as floating emojis on the TV display
- Panel only visible when a song is currently playing

## Implementation
- `server/reactions.js` — WebSocket `send-reaction` handler broadcasts `reaction-received` to session
- `src/components/mobile/ReactionsPanel.tsx` — emoji button row with tap animation
- `src/components/tv/FloatingReactions.tsx` — floating emojis with CSS `float-up` animation
- `src/hooks/useReactions.ts` — listens for reactions, auto-cleans after 3.5s

## Test plan
- [ ] Multi-user Gherkin e2e tests cover: single reaction, multiple simultaneous, hidden when no playback, emoji panel visibility
- [ ] Unit tests pass (1375 tests)
- [ ] Build passes
- [ ] All files under 150-line limit
- [ ] CRAP scores within threshold