### PR TITLE
Add fair queue rotation and favorites/song history

### DIFF
--- a/__tests__/components/mobile/MySongs.test.tsx
+++ b/__tests__/components/mobile/MySongs.test.tsx
@@ -1,0 +1,186 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MySongs } from "@/components/mobile/MySongs";
+import { SongHistoryEntry } from "@/hooks/useSongHistory";
+
+function makeEntry(
+  overrides: Partial<SongHistoryEntry> = {}
+): SongHistoryEntry {
+  return {
+    mediaItem: {
+      jellyfinId: "song-1",
+      title: "Bohemian Rhapsody",
+      artist: "Queen",
+      album: "A Night at the Opera",
+      duration: 354,
+    },
+    lastSungAt: new Date().toISOString(),
+    isFavorite: false,
+    ...overrides,
+  };
+}
+
+describe("MySongs", () => {
+  const mockToggleFavorite = vi.fn();
+  const mockAddSong = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows empty state when no history or favorites", () => {
+    render(
+      <MySongs
+        favorites={[]}
+        recentHistory={[]}
+        onToggleFavorite={mockToggleFavorite}
+        onAddSong={mockAddSong}
+      />
+    );
+
+    expect(screen.getByTestId("my-songs-empty")).toBeInTheDocument();
+    expect(screen.getByText("No songs yet")).toBeInTheDocument();
+  });
+
+  it("shows history section with songs", () => {
+    const entry = makeEntry();
+    render(
+      <MySongs
+        favorites={[]}
+        recentHistory={[entry]}
+        onToggleFavorite={mockToggleFavorite}
+        onAddSong={mockAddSong}
+      />
+    );
+
+    expect(screen.getByTestId("history-section")).toBeInTheDocument();
+    expect(screen.getByText("Bohemian Rhapsody")).toBeInTheDocument();
+    expect(screen.getByText("Queen")).toBeInTheDocument();
+  });
+
+  it("shows favorites section when favorites exist", () => {
+    const entry = makeEntry({ isFavorite: true });
+    render(
+      <MySongs
+        favorites={[entry]}
+        recentHistory={[]}
+        onToggleFavorite={mockToggleFavorite}
+        onAddSong={mockAddSong}
+      />
+    );
+
+    expect(screen.getByTestId("favorites-section")).toBeInTheDocument();
+  });
+
+  it("calls onToggleFavorite when favorite button clicked", () => {
+    const entry = makeEntry();
+    render(
+      <MySongs
+        favorites={[]}
+        recentHistory={[entry]}
+        onToggleFavorite={mockToggleFavorite}
+        onAddSong={mockAddSong}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("favorite-btn-song-1"));
+    expect(mockToggleFavorite).toHaveBeenCalledWith("song-1");
+  });
+
+  it("calls onAddSong when requeue button clicked", () => {
+    const entry = makeEntry();
+    render(
+      <MySongs
+        favorites={[]}
+        recentHistory={[entry]}
+        onToggleFavorite={mockToggleFavorite}
+        onAddSong={mockAddSong}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("requeue-btn-song-1"));
+    expect(mockAddSong).toHaveBeenCalledWith(entry.mediaItem);
+  });
+
+  it("shows 'Just now' for recent timestamps", () => {
+    const entry = makeEntry({ lastSungAt: new Date().toISOString() });
+    render(
+      <MySongs
+        favorites={[]}
+        recentHistory={[entry]}
+        onToggleFavorite={mockToggleFavorite}
+        onAddSong={mockAddSong}
+      />
+    );
+
+    expect(screen.getByText("Just now")).toBeInTheDocument();
+  });
+
+  it("shows minutes ago for timestamps within the hour", () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    const entry = makeEntry({ lastSungAt: fiveMinAgo });
+    render(
+      <MySongs
+        favorites={[]}
+        recentHistory={[entry]}
+        onToggleFavorite={mockToggleFavorite}
+        onAddSong={mockAddSong}
+      />
+    );
+
+    expect(screen.getByText("5m ago")).toBeInTheDocument();
+  });
+
+  it("shows hours ago for timestamps within the day", () => {
+    const threeHoursAgo = new Date(
+      Date.now() - 3 * 60 * 60 * 1000
+    ).toISOString();
+    const entry = makeEntry({ lastSungAt: threeHoursAgo });
+    render(
+      <MySongs
+        favorites={[]}
+        recentHistory={[entry]}
+        onToggleFavorite={mockToggleFavorite}
+        onAddSong={mockAddSong}
+      />
+    );
+
+    expect(screen.getByText("3h ago")).toBeInTheDocument();
+  });
+
+  it("shows days ago for timestamps within the week", () => {
+    const twoDaysAgo = new Date(
+      Date.now() - 2 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    const entry = makeEntry({ lastSungAt: twoDaysAgo });
+    render(
+      <MySongs
+        favorites={[]}
+        recentHistory={[entry]}
+        onToggleFavorite={mockToggleFavorite}
+        onAddSong={mockAddSong}
+      />
+    );
+
+    expect(screen.getByText("2d ago")).toBeInTheDocument();
+  });
+
+  it("shows date for timestamps older than a week", () => {
+    const twoWeeksAgo = new Date(
+      Date.now() - 14 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    const entry = makeEntry({ lastSungAt: twoWeeksAgo });
+    render(
+      <MySongs
+        favorites={[]}
+        recentHistory={[entry]}
+        onToggleFavorite={mockToggleFavorite}
+        onAddSong={mockAddSong}
+      />
+    );
+
+    const timeEl = screen.getByTestId("last-sung-time");
+    expect(timeEl.textContent).not.toContain("ago");
+  });
+});

--- a/__tests__/components/mobile/NavigationTabs.test.tsx
+++ b/__tests__/components/mobile/NavigationTabs.test.tsx
@@ -23,7 +23,7 @@ describe("NavigationTabs", () => {
     expect(screen.getByTestId("queue-tab")).toBeInTheDocument();
   });
 
-  it("displays Search Songs and Queue labels", () => {
+  it("displays Search, Queue, and My Songs labels", () => {
     render(
       <NavigationTabs
         activeTab="search"
@@ -32,8 +32,9 @@ describe("NavigationTabs", () => {
       />
     );
 
-    expect(screen.getByText("Search Songs")).toBeInTheDocument();
+    expect(screen.getByText("Search")).toBeInTheDocument();
     expect(screen.getByText("Queue")).toBeInTheDocument();
+    expect(screen.getByText("My Songs")).toBeInTheDocument();
   });
 
   it("highlights the active search tab", () => {

--- a/__tests__/server/fair-rotation.test.ts
+++ b/__tests__/server/fair-rotation.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { getFairInsertionIndex } from "../../server/fair-rotation";
+
+function makeQueueItem(
+  addedByUserId: string,
+  status: string = "pending",
+  title: string = "Song"
+) {
+  return {
+    id: `queue_${Math.random().toString(36).substr(2, 9)}`,
+    mediaItem: { title, artist: "Artist" },
+    addedBy: addedByUserId,
+    addedByUserId,
+    status,
+  };
+}
+
+describe("getFairInsertionIndex", () => {
+  it("returns end of queue when no pending items", () => {
+    const queue = [makeQueueItem("alice", "playing")];
+    expect(getFairInsertionIndex(queue, "bob")).toBe(1);
+  });
+
+  it("returns end of empty queue", () => {
+    expect(getFairInsertionIndex([], "alice")).toBe(0);
+  });
+
+  it("places new user after first round of existing users", () => {
+    const queue = [
+      makeQueueItem("alice", "pending", "A1"),
+      makeQueueItem("alice", "pending", "A2"),
+      makeQueueItem("alice", "pending", "A3"),
+    ];
+    const idx = getFairInsertionIndex(queue, "bob");
+    expect(idx).toBe(1);
+  });
+
+  it("interleaves two users' songs: A1 B1 A2 B2", () => {
+    const queue = [makeQueueItem("alice", "pending", "A1")];
+
+    // Bob adds - should go after A1
+    let idx = getFairInsertionIndex(queue, "bob");
+    expect(idx).toBe(1);
+    queue.splice(idx, 0, makeQueueItem("bob", "pending", "B1"));
+
+    // Alice adds another - should go after B1
+    idx = getFairInsertionIndex(queue, "alice");
+    expect(idx).toBe(2);
+    queue.splice(idx, 0, makeQueueItem("alice", "pending", "A2"));
+
+    // Bob adds another - should go after A2
+    idx = getFairInsertionIndex(queue, "bob");
+    expect(idx).toBe(3);
+
+    // Result: A1, B1, A2, B2
+  });
+
+  it("new user goes before existing user's pending song when one is playing", () => {
+    const queue = [
+      makeQueueItem("alice", "playing", "A1"),
+      makeQueueItem("alice", "pending", "A2"),
+    ];
+
+    const idx = getFairInsertionIndex(queue, "bob");
+    // Alice's playing song counts as her round-1 slot.
+    // Her pending song is round 2. Bob's round-1 slot goes before it.
+    expect(idx).toBe(1);
+  });
+
+  it("handles three users fairly", () => {
+    const queue: ReturnType<typeof makeQueueItem>[] = [];
+
+    // Alice adds 2
+    let idx = getFairInsertionIndex(queue, "alice");
+    queue.splice(idx, 0, makeQueueItem("alice", "pending", "A1"));
+    idx = getFairInsertionIndex(queue, "alice");
+    queue.splice(idx, 0, makeQueueItem("alice", "pending", "A2"));
+
+    // Bob adds 2
+    idx = getFairInsertionIndex(queue, "bob");
+    queue.splice(idx, 0, makeQueueItem("bob", "pending", "B1"));
+    idx = getFairInsertionIndex(queue, "bob");
+    queue.splice(idx, 0, makeQueueItem("bob", "pending", "B2"));
+
+    // Charlie adds 2
+    idx = getFairInsertionIndex(queue, "charlie");
+    queue.splice(idx, 0, makeQueueItem("charlie", "pending", "C1"));
+    idx = getFairInsertionIndex(queue, "charlie");
+    queue.splice(idx, 0, makeQueueItem("charlie", "pending", "C2"));
+
+    const order = queue.map(q => q.mediaItem.title);
+    // First round should have one from each: A1, B1, C1
+    expect(order[0]).toBe("A1");
+    expect(order[1]).toBe("B1");
+    expect(order[2]).toBe("C1");
+    // Second round: A2, B2, C2
+    expect(order[3]).toBe("A2");
+    expect(order[4]).toBe("B2");
+    expect(order[5]).toBe("C2");
+  });
+
+  it("bob's song not last when alice adds 3 and bob adds 1", () => {
+    const queue: ReturnType<typeof makeQueueItem>[] = [];
+
+    // Alice adds 3
+    let idx = getFairInsertionIndex(queue, "alice");
+    queue.splice(idx, 0, makeQueueItem("alice", "pending", "A1"));
+    idx = getFairInsertionIndex(queue, "alice");
+    queue.splice(idx, 0, makeQueueItem("alice", "pending", "A2"));
+    idx = getFairInsertionIndex(queue, "alice");
+    queue.splice(idx, 0, makeQueueItem("alice", "pending", "A3"));
+
+    // Bob adds 1
+    idx = getFairInsertionIndex(queue, "bob");
+    queue.splice(idx, 0, makeQueueItem("bob", "pending", "B1"));
+
+    const order = queue.map(q => q.mediaItem.title);
+    // Bob should be second (after A1), not last
+    expect(order[1]).toBe("B1");
+    expect(order[order.length - 1]).not.toBe("B1");
+  });
+
+  it("second user's song placed before first user's second song", () => {
+    const queue: ReturnType<typeof makeQueueItem>[] = [];
+
+    // Alice adds 2
+    let idx = getFairInsertionIndex(queue, "alice");
+    queue.splice(idx, 0, makeQueueItem("alice", "pending", "A1"));
+    idx = getFairInsertionIndex(queue, "alice");
+    queue.splice(idx, 0, makeQueueItem("alice", "pending", "A2"));
+
+    // Bob adds 1
+    idx = getFairInsertionIndex(queue, "bob");
+    queue.splice(idx, 0, makeQueueItem("bob", "pending", "B1"));
+
+    const order = queue.map(q => q.mediaItem.title);
+    expect(order).toEqual(["A1", "B1", "A2"]);
+  });
+});

--- a/e2e/features/fair-rotation.feature
+++ b/e2e/features/fair-rotation.feature
@@ -1,0 +1,23 @@
+@multi-user
+Feature: Fair Queue Rotation
+  As karaoke participants sharing a session
+  We want songs to be ordered fairly across singers
+  So that one person cannot monopolize the queue
+
+  Scenario: Second user's song is placed before first user's second song
+    Given "Alice" has joined the session on device 1
+    And "Bob" has joined the session on device 2
+    And the queue is empty
+    When Alice adds two songs to the queue
+    And Bob adds a song to the queue
+    Then the queue shows Bob's song in second position
+
+  Scenario: Three users get fair rotation
+    Given "Alice" has joined the session on device 1
+    And "Bob" has joined the session on device 2
+    And "Charlie" has joined the session on device 3
+    And the queue is empty
+    When Alice adds a song to the queue
+    And Bob adds a song to the queue
+    And Charlie adds a song to the queue
+    Then the queue order is Alice, Bob, Charlie

--- a/e2e/features/favorites-history.feature
+++ b/e2e/features/favorites-history.feature
@@ -1,0 +1,19 @@
+@mobile
+Feature: Favorites and Song History
+  As a returning karaoke singer
+  I want to see songs I've previously queued and mark favorites
+  So that I can quickly find and re-queue my go-to songs
+
+  Background:
+    Given the user has completed setup with name "TestUser"
+
+  Scenario: Added song appears in My Songs history
+    When I add a song to the queue
+    And I navigate to the My Songs tab
+    Then I should see the song in my history
+
+  Scenario: Marking a song as favorite moves it to Favorites section
+    When I add a song to the queue
+    And I navigate to the My Songs tab
+    And I tap the favorite button on the song
+    Then the song appears in the Favorites section

--- a/e2e/steps/fair-rotation.steps.ts
+++ b/e2e/steps/fair-rotation.steps.ts
@@ -1,0 +1,239 @@
+import { expect, Page, BrowserContext } from "@playwright/test";
+import { test as base, createBdd } from "playwright-bdd";
+
+const test = base.extend<{
+  alicePage: Page;
+  aliceContext: BrowserContext;
+  bobPage: Page;
+  bobContext: BrowserContext;
+  charliePage: Page;
+  charlieContext: BrowserContext;
+  tvPage: Page;
+  tvContext: BrowserContext;
+}>({
+  aliceContext: async ({ browser }, use) => {
+    const context = await browser.newContext();
+    await use(context);
+    await context.close();
+  },
+  alicePage: async ({ aliceContext }, use) => {
+    const page = await aliceContext.newPage();
+    await use(page);
+  },
+  bobContext: async ({ browser }, use) => {
+    const context = await browser.newContext();
+    await use(context);
+    await context.close();
+  },
+  bobPage: async ({ bobContext }, use) => {
+    const page = await bobContext.newPage();
+    await use(page);
+  },
+  charlieContext: async ({ browser }, use) => {
+    const context = await browser.newContext();
+    await use(context);
+    await context.close();
+  },
+  charliePage: async ({ charlieContext }, use) => {
+    const page = await charlieContext.newPage();
+    await use(page);
+  },
+  tvContext: async ({ browser }, use) => {
+    const context = await browser.newContext();
+    await use(context);
+    await context.close();
+  },
+  tvPage: async ({ tvContext }, use) => {
+    const page = await tvContext.newPage();
+    await use(page);
+  },
+});
+
+export { test };
+const { Given, When, Then } = createBdd(test);
+
+async function clearQueue(page: Page): Promise<void> {
+  const response = await page.request.get("http://localhost:3000/api/queue");
+  const data = await response.json();
+  const queue = data?.data?.queue || data?.queue || [];
+  for (const item of queue) {
+    if (item.status === "playing") {
+      await page.request.put("http://localhost:3000/api/queue", {
+        data: { action: "skip", userId: item.addedBy || "cleanup" },
+      });
+    } else {
+      await page.request.delete(
+        `http://localhost:3000/api/queue?itemId=${item.id}&userId=${item.addedBy || "cleanup"}`
+      );
+    }
+  }
+  const recheck = await page.request.get("http://localhost:3000/api/queue");
+  const recheckData = await recheck.json();
+  const remaining = recheckData?.data?.queue || recheckData?.queue || [];
+  for (const item of remaining) {
+    if (item.status === "playing") {
+      await page.request.put("http://localhost:3000/api/queue", {
+        data: { action: "skip", userId: item.addedBy || "cleanup" },
+      });
+    } else {
+      await page.request.delete(
+        `http://localhost:3000/api/queue?itemId=${item.id}&userId=${item.addedBy || "cleanup"}`
+      );
+    }
+  }
+}
+
+async function joinSession(page: Page, userName: string): Promise<void> {
+  await page.goto("/");
+  await page.waitForLoadState("domcontentloaded");
+  await clearQueue(page);
+  await page.evaluate(() => {
+    localStorage.removeItem("karaoke-username");
+  });
+  await page.reload();
+  await page.waitForLoadState("domcontentloaded");
+  await page.locator("[data-testid='username-input']").fill(userName);
+  await page.locator("[data-testid='join-session-button']").click();
+  await expect(page.locator("[data-testid='search-tab']")).toBeVisible({
+    timeout: 10000,
+  });
+}
+
+async function dismissConfirmation(page: Page): Promise<void> {
+  const dialog = page.locator("[data-testid='confirmation-dialog']");
+  await dialog.waitFor({ timeout: 10000 });
+  await dialog.locator("button[aria-label='Close']").click();
+  await dialog.waitFor({ state: "hidden", timeout: 5000 });
+}
+
+async function addSongFromArtist(
+  page: Page,
+  artistIndex: number
+): Promise<void> {
+  await page.locator("[data-testid='search-tab']").click();
+  await page.waitForTimeout(500);
+
+  const backButton = page.locator("[data-testid='back-button']");
+  if (await backButton.isVisible().catch(() => false)) {
+    await backButton.click();
+    await page.waitForTimeout(500);
+  }
+
+  await page
+    .locator("[data-testid='artist-item']")
+    .nth(artistIndex)
+    .waitFor({ timeout: 60000 });
+
+  await page.locator("[data-testid='artist-item']").nth(artistIndex).click();
+
+  await page
+    .locator("[data-testid='add-song-button']")
+    .first()
+    .waitFor({ timeout: 30000 });
+
+  await page.locator("[data-testid='add-song-button']").first().click();
+  await dismissConfirmation(page);
+}
+
+Given(
+  "{string} has joined the session on device 1",
+  async ({ alicePage }, name: string) => {
+    await joinSession(alicePage, name);
+  }
+);
+
+Given(
+  "{string} has joined the session on device 2",
+  async ({ bobPage }, name: string) => {
+    await joinSession(bobPage, name);
+  }
+);
+
+Given(
+  "{string} has joined the session on device 3",
+  async ({ charliePage }, name: string) => {
+    await joinSession(charliePage, name);
+  }
+);
+
+Given("the queue is empty", async ({ alicePage }) => {
+  await clearQueue(alicePage);
+  await alicePage.waitForTimeout(1000);
+});
+
+When("Alice adds two songs to the queue", async ({ alicePage }) => {
+  await addSongFromArtist(alicePage, 0);
+  await addSongFromArtist(alicePage, 1);
+});
+
+When("Alice adds a song to the queue", async ({ alicePage }) => {
+  await addSongFromArtist(alicePage, 0);
+});
+
+When("Bob adds a song to the queue", async ({ bobPage }) => {
+  await addSongFromArtist(bobPage, 1);
+});
+
+When("Charlie adds a song to the queue", async ({ charliePage }) => {
+  await addSongFromArtist(charliePage, 2);
+});
+
+async function getQueueFromSocket(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    return new Promise<string[]>(resolve => {
+      const socket = (
+        window as unknown as { __socket?: { emit: Function; on: Function } }
+      ).__socket;
+      if (!socket) {
+        resolve([]);
+        return;
+      }
+      socket.emit("get-queue");
+      socket.on("queue-updated", (queue: Array<{ addedBy: string }>) => {
+        resolve(queue.map(item => item.addedBy));
+      });
+      setTimeout(() => resolve([]), 3000);
+    });
+  });
+}
+
+Then("the queue shows Bob's song in second position", async ({ bobPage }) => {
+  await bobPage.locator("[data-testid='queue-tab']").click();
+  await bobPage.waitForTimeout(2000);
+
+  const queueItems = bobPage.locator(
+    "[data-testid='queue-item'], [data-testid='now-playing']"
+  );
+  await expect(queueItems.first()).toBeVisible({ timeout: 10000 });
+
+  const count = await queueItems.count();
+  expect(count).toBeGreaterThanOrEqual(2);
+
+  // From Bob's view: now-playing (Alice), then Bob's song ("You" or "Your song")
+  // Bob's song should be first in the pending list (second overall)
+  const secondItem = queueItems.nth(1);
+  const secondText = await secondItem.textContent();
+  expect(secondText).toContain("You");
+});
+
+Then("the queue order is Alice, Bob, Charlie", async ({ charliePage }) => {
+  await charliePage.locator("[data-testid='queue-tab']").click();
+  await charliePage.waitForTimeout(2000);
+
+  const queueItems = charliePage.locator(
+    "[data-testid='queue-item'], [data-testid='now-playing']"
+  );
+  await expect(queueItems.first()).toBeVisible({ timeout: 10000 });
+
+  const count = await queueItems.count();
+  expect(count).toBeGreaterThanOrEqual(3);
+
+  // From Charlie's perspective: Alice's song, Bob's song, Charlie's ("You")
+  const firstText = await queueItems.nth(0).textContent();
+  const secondText = await queueItems.nth(1).textContent();
+  const thirdText = await queueItems.nth(2).textContent();
+
+  expect(firstText).toContain("Alice");
+  expect(secondText).toContain("Bob");
+  expect(thirdText).toContain("You");
+});

--- a/e2e/steps/favorites-history.steps.ts
+++ b/e2e/steps/favorites-history.steps.ts
@@ -1,0 +1,71 @@
+import { expect } from "@playwright/test";
+import { Given, When, Then } from "./fixtures";
+
+Given(
+  "the user has completed setup with name {string}",
+  async ({ page }, name: string) => {
+    await page.goto("/");
+    await page.evaluate(userName => {
+      localStorage.setItem("karaoke-username", userName);
+      localStorage.removeItem(`karaoke-song-history-${userName}`);
+    }, name);
+    await page.reload();
+    await page.waitForLoadState("domcontentloaded");
+    await page
+      .locator("[data-testid='connection-status']")
+      .waitFor({ timeout: 10000 });
+    await page.waitForTimeout(500);
+  }
+);
+
+When("I add a song to the queue", async ({ page }) => {
+  await page.locator("[data-testid='search-tab']").click();
+  await page.waitForTimeout(500);
+
+  await page
+    .locator("[data-testid='artist-item']")
+    .first()
+    .waitFor({ timeout: 60000 });
+
+  await page.locator("[data-testid='artist-item']").first().click();
+
+  await page
+    .locator("[data-testid='add-song-button']")
+    .first()
+    .waitFor({ timeout: 30000 });
+
+  await page.locator("[data-testid='add-song-button']").first().click();
+
+  const dialog = page.locator("[data-testid='confirmation-dialog']");
+  await dialog.waitFor({ timeout: 10000 });
+  await dialog.locator("button[aria-label='Close']").click();
+  await dialog.waitFor({ state: "hidden", timeout: 5000 });
+});
+
+When("I navigate to the My Songs tab", async ({ page }) => {
+  await page.locator("[data-testid='my-songs-tab']").click();
+  await page.waitForTimeout(500);
+});
+
+When("I tap the favorite button on the song", async ({ page }) => {
+  const historyItem = page.locator("[data-testid='song-history-item']").first();
+  await historyItem.waitFor({ timeout: 10000 });
+  const favBtn = page.locator("[data-testid^='favorite-btn-']").first();
+  await favBtn.click();
+});
+
+Then("I should see the song in my history", async ({ page }) => {
+  const historySection = page.locator("[data-testid='history-section']");
+  await expect(historySection).toBeVisible({ timeout: 5000 });
+
+  const historyItem = page.locator("[data-testid='song-history-item']").first();
+  await expect(historyItem).toBeVisible({ timeout: 5000 });
+});
+
+Then("the song appears in the Favorites section", async ({ page }) => {
+  const favSection = page.locator("[data-testid='favorites-section']");
+  await expect(favSection).toBeVisible({ timeout: 5000 });
+
+  const favItem = favSection.locator("[data-testid='song-history-item']");
+  await expect(favItem.first()).toBeVisible({ timeout: 5000 });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,6 +41,18 @@ const audienceReactionsTestDir = defineBddConfig({
   steps: "e2e/steps/audience-reactions.steps.ts",
 });
 
+const fairRotationTestDir = defineBddConfig({
+  outputDir: ".features-gen/fair-rotation",
+  features: "e2e/features/fair-rotation.feature",
+  steps: "e2e/steps/fair-rotation.steps.ts",
+});
+
+const favoritesHistoryTestDir = defineBddConfig({
+  outputDir: ".features-gen/favorites-history",
+  features: "e2e/features/favorites-history.feature",
+  steps: "e2e/steps/favorites-history.steps.ts",
+});
+
 const fullPlaybackTestDir = defineBddConfig({
   outputDir: ".features-gen/full-playback",
   features: "e2e/features/full-playback.feature",
@@ -81,6 +93,19 @@ export default defineConfig({
       testDir: adminSyncTestDir,
       use: { ...devices["Desktop Chrome"] },
       timeout: 90000,
+    },
+    {
+      name: "fair-rotation",
+      testDir: fairRotationTestDir,
+      use: { ...devices["Desktop Chrome"] },
+      timeout: 90000,
+    },
+    {
+      name: "favorites-history",
+      testDir: favoritesHistoryTestDir,
+      use: { ...devices["Desktop Chrome"] },
+      timeout: 60000,
+      fullyParallel: false,
     },
     {
       name: "full-playback",

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const next = require("next");
 const { Server } = require("socket.io");
 const fetch = require("node-fetch");
 const { handleSendReaction } = require("./server/reactions");
+const { getFairInsertionIndex } = require("./server/fair-rotation");
 
 // Simple rating generator for server-side use
 function generateRandomRating() {
@@ -504,7 +505,8 @@ app.prepare().then(() => {
       if (position !== undefined) {
         currentSession.queue.splice(position, 0, queueItem);
       } else {
-        currentSession.queue.push(queueItem);
+        const fairIndex = getFairInsertionIndex(currentSession.queue, user.id);
+        currentSession.queue.splice(fairIndex, 0, queueItem);
       }
 
       // Update positions

--- a/server/fair-rotation.js
+++ b/server/fair-rotation.js
@@ -1,0 +1,101 @@
+/**
+ * Fair round-robin queue insertion.
+ *
+ * Inserts a new song so the queue interleaves fairly between users.
+ * The currently playing song (if any) counts as that user's first turn.
+ * Only reorders among "pending" items — playing/completed items stay put.
+ */
+function getFairInsertionIndex(queue, addedByUserId) {
+  const pending = [];
+  for (let i = 0; i < queue.length; i++) {
+    if (queue[i].status === "pending") {
+      pending.push({ item: queue[i], idx: i });
+    }
+  }
+
+  if (pending.length === 0) {
+    return queue.length;
+  }
+
+  const playingSong = queue.find(item => item.status === "playing");
+  const playingUserId = playingSong ? playingSong.addedByUserId : null;
+
+  const userPendingCount = pending.filter(
+    e => e.item.addedByUserId === addedByUserId
+  ).length;
+
+  if (userPendingCount === 0) {
+    const insertPos = findSlotForNewUser(pending, playingUserId);
+    if (insertPos >= pending.length) {
+      return queue.length;
+    }
+    return pending[insertPos].idx;
+  }
+
+  const insertPos = findSlotForExistingUser(pending, addedByUserId);
+  if (insertPos >= pending.length) {
+    return queue.length;
+  }
+  return pending[insertPos].idx;
+}
+
+/**
+ * For a user with no pending songs: find where round 1 ends.
+ * The playing user already "used" their round-1 slot, so their first
+ * pending song starts round 2. A new user's song belongs in round 1.
+ */
+function findSlotForNewUser(pending, playingUserId) {
+  const seen = new Set();
+  if (playingUserId) {
+    seen.add(playingUserId);
+  }
+
+  for (let i = 0; i < pending.length; i++) {
+    const uid = pending[i].item.addedByUserId;
+    if (seen.has(uid)) {
+      return i;
+    }
+    seen.add(uid);
+  }
+  return pending.length;
+}
+
+/**
+ * For a user who already has pending songs: find their last pending song,
+ * then skip past one song from each OTHER distinct user.
+ */
+function findSlotForExistingUser(pending, userId) {
+  let lastOwnIdx = -1;
+  for (let i = pending.length - 1; i >= 0; i--) {
+    if (pending[i].item.addedByUserId === userId) {
+      lastOwnIdx = i;
+      break;
+    }
+  }
+
+  if (lastOwnIdx === -1) {
+    return pending.length;
+  }
+
+  const otherUsers = new Set();
+  for (const entry of pending) {
+    if (entry.item.addedByUserId !== userId) {
+      otherUsers.add(entry.item.addedByUserId);
+    }
+  }
+
+  let pos = lastOwnIdx + 1;
+  const othersToSkip = otherUsers.size;
+  let skipped = 0;
+
+  while (pos < pending.length && skipped < othersToSkip) {
+    if (pending[pos].item.addedByUserId !== userId) {
+      skipped++;
+    }
+    pos++;
+  }
+
+  return pos;
+}
+
+module.exports = { getFairInsertionIndex };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,16 +5,15 @@ import { useWebSocket } from "@/hooks/useWebSocket";
 import { SearchInterface } from "@/components/mobile/SearchInterface";
 import { QueueView } from "@/components/mobile/QueueView";
 import { UserSetup } from "@/components/mobile/UserSetup";
-import { NavigationTabs } from "@/components/mobile/NavigationTabs";
+import { NavigationTabs, TabType } from "@/components/mobile/NavigationTabs";
 import { ReactionsPanel } from "@/components/mobile/ReactionsPanel";
+import { MySongs } from "@/components/mobile/MySongs";
+import { AppHeader } from "@/components/mobile/AppHeader";
+import { useSongHistory } from "@/hooks/useSongHistory";
 import { PWAInstaller } from "@/components/PWAInstaller";
-import {
-  getConnectionStatusColor,
-  getConnectionStatusText,
-} from "./pageHelpers";
 
 export default function Home() {
-  const [activeTab, setActiveTab] = useState<"search" | "queue">("search");
+  const [activeTab, setActiveTab] = useState<TabType>("search");
   const [userName, setUserName] = useState<string>("");
   const [isSetup, setIsSetup] = useState(false);
   const [isClient, setIsClient] = useState(false);
@@ -31,13 +30,14 @@ export default function Home() {
     error,
   } = useWebSocket();
 
-  // Prevent hydration mismatch by only rendering WebSocket-dependent content on client
+  const { favorites, recentHistory, addToHistory, toggleFavorite } =
+    useSongHistory(userName);
+
   useEffect(() => {
     setIsClient(true);
   }, []);
 
   useEffect(() => {
-    // Check if user has already set up their name
     const savedUserName = localStorage.getItem("karaoke-username");
     if (savedUserName) {
       setUserName(savedUserName);
@@ -45,12 +45,16 @@ export default function Home() {
     }
   }, []);
 
-  // Auto-join session when connected and user is set up
   useEffect(() => {
     if (isConnected && isSetup && userName && !session) {
       joinSession("main-session", userName);
     }
   }, [isConnected, isSetup, userName, session, joinSession]);
+
+  const handleAddSong = async (mediaItem: Parameters<typeof addSong>[0]) => {
+    await addSong(mediaItem);
+    addToHistory(mediaItem);
+  };
 
   const handleUserSetup = (name: string) => {
     setUserName(name);
@@ -63,7 +67,6 @@ export default function Home() {
     return <UserSetup onSetup={handleUserSetup} />;
   }
 
-  // Prevent hydration mismatch by only rendering WebSocket-dependent content on client
   if (!isClient) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
@@ -74,56 +77,23 @@ export default function Home() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <div className="bg-white shadow-sm border-b">
-        <div className="px-4 py-3">
-          <h1 className="text-lg font-semibold text-gray-900">
-            Karaoke For Jellyfin
-          </h1>
-          <div className="flex items-center mt-1">
-            <div
-              className={`w-2 h-2 rounded-full mr-2 ${getConnectionStatusColor(isConnected, error)}`}
-            />
-            <span
-              data-testid="connection-status"
-              className="text-sm text-gray-600"
-            >
-              {getConnectionStatusText(isConnected, userName, error)}
-            </span>
-          </div>
-        </div>
-      </div>
-
-      {/* Error Banner */}
-      {error && (
-        <div className="bg-red-50 border-l-4 border-red-400 p-4 mx-4 mt-4">
-          <div className="flex">
-            <div className="ml-3">
-              <p data-testid="error-message" className="text-sm text-red-700">
-                {error}
-              </p>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Navigation Tabs */}
+      <AppHeader isConnected={isConnected} userName={userName} error={error} />
       <NavigationTabs
         activeTab={activeTab}
         onTabChange={setActiveTab}
         queueCount={queue.filter(item => item.status === "pending").length}
       />
-
-      {/* Reactions FAB - visible during playback */}
       {currentSong && <ReactionsPanel onReaction={sendReaction} />}
-
-      {/* Main Content */}
       <div className="flex-1 overflow-hidden">
-        {activeTab === "search" ? (
+        {activeTab === "search" && (
           <div data-testid="search-content">
-            <SearchInterface onAddSong={addSong} isConnected={isConnected} />
+            <SearchInterface
+              onAddSong={handleAddSong}
+              isConnected={isConnected}
+            />
           </div>
-        ) : (
+        )}
+        {activeTab === "queue" && (
           <div data-testid="queue-content">
             <QueueView
               queue={queue}
@@ -134,9 +104,17 @@ export default function Home() {
             />
           </div>
         )}
+        {activeTab === "my-songs" && (
+          <div data-testid="my-songs-content">
+            <MySongs
+              favorites={favorites}
+              recentHistory={recentHistory}
+              onToggleFavorite={toggleFavorite}
+              onAddSong={handleAddSong}
+            />
+          </div>
+        )}
       </div>
-
-      {/* PWA Install Prompt */}
       <PWAInstaller />
     </div>
   );

--- a/src/components/mobile/AppHeader.tsx
+++ b/src/components/mobile/AppHeader.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import {
+  getConnectionStatusColor,
+  getConnectionStatusText,
+} from "@/app/pageHelpers";
+
+interface AppHeaderProps {
+  isConnected: boolean;
+  userName: string;
+  error: string | null;
+}
+
+export function AppHeader({ isConnected, userName, error }: AppHeaderProps) {
+  return (
+    <>
+      <div className="bg-white shadow-sm border-b">
+        <div className="px-4 py-3">
+          <h1 className="text-lg font-semibold text-gray-900">
+            Karaoke For Jellyfin
+          </h1>
+          <div className="flex items-center mt-1">
+            <div
+              className={`w-2 h-2 rounded-full mr-2 ${getConnectionStatusColor(isConnected, error)}`}
+            />
+            <span
+              data-testid="connection-status"
+              className="text-sm text-gray-600"
+            >
+              {getConnectionStatusText(isConnected, userName, error)}
+            </span>
+          </div>
+        </div>
+      </div>
+      {error && (
+        <div className="bg-red-50 border-l-4 border-red-400 p-4 mx-4 mt-4">
+          <p data-testid="error-message" className="text-sm text-red-700">
+            {error}
+          </p>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/mobile/MySongs.tsx
+++ b/src/components/mobile/MySongs.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { SongHistoryEntry } from "@/hooks/useSongHistory";
+import { MediaItem } from "@/types";
+
+interface MySongsProps {
+  favorites: SongHistoryEntry[];
+  recentHistory: SongHistoryEntry[];
+  onToggleFavorite: (jellyfinId: string) => void;
+  onAddSong: (mediaItem: MediaItem) => void;
+}
+
+function formatRelativeTime(isoDate: string): string {
+  const diff = Date.now() - new Date(isoDate).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "Just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(isoDate).toLocaleDateString();
+}
+
+export function MySongs({
+  favorites,
+  recentHistory,
+  onToggleFavorite,
+  onAddSong,
+}: MySongsProps) {
+  if (favorites.length === 0 && recentHistory.length === 0) {
+    return (
+      <div
+        data-testid="my-songs-empty"
+        className="flex flex-col items-center justify-center py-16 px-4 text-center"
+      >
+        <p className="text-gray-500 text-lg">No songs yet</p>
+        <p className="text-gray-400 text-sm mt-2">
+          Songs you add to the queue will appear here
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pb-20">
+      {favorites.length > 0 && (
+        <section data-testid="favorites-section">
+          <h2 className="px-4 py-2 text-sm font-semibold text-gray-500 uppercase bg-gray-100">
+            Favorites
+          </h2>
+          {favorites.map(entry => (
+            <SongRow
+              key={entry.mediaItem.jellyfinId}
+              entry={entry}
+              onToggleFavorite={onToggleFavorite}
+              onAddSong={onAddSong}
+            />
+          ))}
+        </section>
+      )}
+
+      {recentHistory.length > 0 && (
+        <section data-testid="history-section">
+          <h2 className="px-4 py-2 text-sm font-semibold text-gray-500 uppercase bg-gray-100">
+            History
+          </h2>
+          {recentHistory.map(entry => (
+            <SongRow
+              key={entry.mediaItem.jellyfinId}
+              entry={entry}
+              onToggleFavorite={onToggleFavorite}
+              onAddSong={onAddSong}
+            />
+          ))}
+        </section>
+      )}
+    </div>
+  );
+}
+
+interface SongRowProps {
+  entry: SongHistoryEntry;
+  onToggleFavorite: (jellyfinId: string) => void;
+  onAddSong: (mediaItem: MediaItem) => void;
+}
+
+function SongRow({ entry, onToggleFavorite, onAddSong }: SongRowProps) {
+  return (
+    <div
+      data-testid="song-history-item"
+      className="flex items-center px-4 py-3 border-b border-gray-100"
+    >
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-gray-900 truncate">
+          {entry.mediaItem.title}
+        </p>
+        <p className="text-xs text-gray-500 truncate">
+          {entry.mediaItem.artist}
+        </p>
+        <p
+          data-testid="last-sung-time"
+          className="text-xs text-gray-400 mt-0.5"
+        >
+          {formatRelativeTime(entry.lastSungAt)}
+        </p>
+      </div>
+      <button
+        data-testid={`favorite-btn-${entry.mediaItem.jellyfinId}`}
+        onClick={() => onToggleFavorite(entry.mediaItem.jellyfinId)}
+        className="p-2 text-xl"
+        aria-label={
+          entry.isFavorite ? "Remove from favorites" : "Add to favorites"
+        }
+      >
+        {entry.isFavorite ? "⭐" : "☆"}
+      </button>
+      <button
+        data-testid={`requeue-btn-${entry.mediaItem.jellyfinId}`}
+        onClick={() => onAddSong(entry.mediaItem)}
+        className="p-2 ml-1 bg-purple-600 text-white text-xs rounded-lg px-3"
+        aria-label={`Add ${entry.mediaItem.title} to queue`}
+      >
+        + Queue
+      </button>
+    </div>
+  );
+}

--- a/src/components/mobile/NavigationTabs.tsx
+++ b/src/components/mobile/NavigationTabs.tsx
@@ -3,11 +3,14 @@
 import {
   MagnifyingGlassIcon,
   QueueListIcon,
+  MusicalNoteIcon,
 } from "@heroicons/react/24/outline";
 
+export type TabType = "search" | "queue" | "my-songs";
+
 interface NavigationTabsProps {
-  activeTab: "search" | "queue";
-  onTabChange: (tab: "search" | "queue") => void;
+  activeTab: TabType;
+  onTabChange: (tab: TabType) => void;
   queueCount: number;
 }
 
@@ -28,8 +31,8 @@ export function NavigationTabs({
               : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
           }`}
         >
-          <MagnifyingGlassIcon className="w-5 h-5 mr-2" />
-          Search Songs
+          <MagnifyingGlassIcon className="w-5 h-5 mr-1" />
+          Search
         </button>
 
         <button
@@ -41,13 +44,26 @@ export function NavigationTabs({
               : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
           }`}
         >
-          <QueueListIcon className="w-5 h-5 mr-2" />
+          <QueueListIcon className="w-5 h-5 mr-1" />
           Queue
           {queueCount > 0 && (
-            <span className="ml-2 bg-purple-600 text-white text-xs rounded-full px-2 py-1 min-w-[20px] h-5 flex items-center justify-center">
+            <span className="ml-1 bg-purple-600 text-white text-xs rounded-full px-2 py-1 min-w-[20px] h-5 flex items-center justify-center">
               {queueCount}
             </span>
           )}
+        </button>
+
+        <button
+          data-testid="my-songs-tab"
+          onClick={() => onTabChange("my-songs")}
+          className={`flex-1 flex items-center justify-center py-4 px-4 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === "my-songs"
+              ? "border-purple-500 text-purple-600 bg-purple-50 active"
+              : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+          }`}
+        >
+          <MusicalNoteIcon className="w-5 h-5 mr-1" />
+          My Songs
         </button>
       </div>
     </div>

--- a/src/hooks/useSongHistory.ts
+++ b/src/hooks/useSongHistory.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { MediaItem } from "@/types";
+
+export interface SongHistoryEntry {
+  mediaItem: MediaItem;
+  lastSungAt: string;
+  isFavorite: boolean;
+}
+
+const STORAGE_KEY_PREFIX = "karaoke-song-history-";
+
+function getStorageKey(userName: string): string {
+  return `${STORAGE_KEY_PREFIX}${userName}`;
+}
+
+function loadHistory(userName: string): SongHistoryEntry[] {
+  if (typeof window === "undefined") return [];
+  const raw = localStorage.getItem(getStorageKey(userName));
+  if (!raw) return [];
+  return JSON.parse(raw);
+}
+
+function saveHistory(userName: string, history: SongHistoryEntry[]): void {
+  localStorage.setItem(getStorageKey(userName), JSON.stringify(history));
+}
+
+export function useSongHistory(userName: string) {
+  const [history, setHistory] = useState<SongHistoryEntry[]>([]);
+
+  useEffect(() => {
+    setHistory(loadHistory(userName));
+  }, [userName]);
+
+  const addToHistory = useCallback(
+    (mediaItem: MediaItem) => {
+      setHistory(prev => {
+        const existing = prev.findIndex(
+          e => e.mediaItem.jellyfinId === mediaItem.jellyfinId
+        );
+        let updated: SongHistoryEntry[];
+
+        if (existing >= 0) {
+          updated = [...prev];
+          updated[existing] = {
+            ...updated[existing],
+            lastSungAt: new Date().toISOString(),
+          };
+        } else {
+          updated = [
+            ...prev,
+            {
+              mediaItem,
+              lastSungAt: new Date().toISOString(),
+              isFavorite: false,
+            },
+          ];
+        }
+
+        saveHistory(userName, updated);
+        return updated;
+      });
+    },
+    [userName]
+  );
+
+  const toggleFavorite = useCallback(
+    (jellyfinId: string) => {
+      setHistory(prev => {
+        const updated = prev.map(entry =>
+          entry.mediaItem.jellyfinId === jellyfinId
+            ? { ...entry, isFavorite: !entry.isFavorite }
+            : entry
+        );
+        saveHistory(userName, updated);
+        return updated;
+      });
+    },
+    [userName]
+  );
+
+  const favorites = history.filter(e => e.isFavorite);
+  const recentHistory = [...history]
+    .sort(
+      (a, b) =>
+        new Date(b.lastSungAt).getTime() - new Date(a.lastSungAt).getTime()
+    )
+    .filter(e => !e.isFavorite);
+
+  return { history, favorites, recentHistory, addToHistory, toggleFavorite };
+}


### PR DESCRIPTION
## Summary
- **Fair queue rotation**: When multiple users are adding songs, new additions are interleaved round-robin style rather than appended to the end. The algorithm accounts for the currently playing song as part of a user's "turn."
- **Favorites & song history**: New "My Songs" tab (3rd tab in mobile nav) backed by localStorage. Shows recently queued songs with timestamps, allows marking favorites for quick re-queue access.

## Changes
- `server/fair-rotation.js` — round-robin insertion algorithm
- `server.js` — uses fair insertion instead of `queue.push()`
- `src/hooks/useSongHistory.ts` — localStorage-based per-user history
- `src/components/mobile/MySongs.tsx` — My Songs tab UI
- `src/components/mobile/AppHeader.tsx` — extracted header for file-length compliance
- `src/components/mobile/NavigationTabs.tsx` — added 3rd "My Songs" tab
- `src/app/page.tsx` — integrated both features
- `playwright.config.ts` — 2 new E2E test projects

## Test plan
- [x] Unit tests for fair-rotation algorithm (8 tests)
- [x] E2E: fair-rotation (2 scenarios — two-user interleave, three-user rotation)
- [x] E2E: favorites-history (2 scenarios — history appears, favorites toggle)
- [x] Existing multi-user E2E tests still pass (5 scenarios)
- [x] All 1394 unit tests pass
- [x] CRAP score check passes
- [x] Build passes